### PR TITLE
Version 2.1.0.0 RC0

### DIFF
--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.1
+-- Version 2.9.5.2
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.4.2
+-- Version 2.9.5.0
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.8
+-- Version 2.9.5.9
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.5
+-- Version 2.9.5.6
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -497,8 +497,8 @@ function HeadlandManagementGui:onClickOk()
 	self.spec.useRidgeMarker = self.ridgeMarkerSetting:getState() == 1
 	-- crab steering
 	self.spec.csState = self.crabSteeringSetting:getState()
-	self.spec.useCrabSteering = (csState ~= 3)
-	self.spec.useCrabSteeringTwoStep = (csState == 2)
+	self.spec.useCrabSteering = (self.spec.csState ~= 3)
+	self.spec.useCrabSteeringTwoStep = (self.spec.csState == 2)
 	-- gps
 	self.spec.useGPS = self.gpsOnOffSetting:getState() == 1
 	self.spec.gpsSetting = self.gpsSetting:getState()

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.2
+-- Version 2.9.5.3
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.3
+-- Version 2.9.5.5
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.0
+-- Version 2.9.5.1
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.7
+-- Version 2.9.5.8
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.6
+-- Version 2.9.5.7
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.9.0
+-- Version 2.1.0.0 RC0
 --
 
 HeadlandManagementGui = {}

--- a/gui/HeadlandManagementGui.lua
+++ b/gui/HeadlandManagementGui.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.9
+-- Version 2.9.9.0
 --
 
 HeadlandManagementGui = {}

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.1
+-- Version 2.9.5.2
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node
@@ -48,6 +48,8 @@ HeadlandManagement.isDedi = g_dedicatedServerInfo ~= nil
 
 HeadlandManagement.BEEPSOUND = createSample("HLMBEEP")
 loadSample(HeadlandManagement.BEEPSOUND, g_currentModDirectory.."sound/beep.ogg", false)
+
+HeadlandManagement.sideInfo = SideNotification.new(nil, "dataS/menu/hud/hud_elements.png")
 
 HeadlandManagement.guiIconOff = createImageOverlay(g_currentModDirectory.."gui/hlm_off.dds")
 HeadlandManagement.guiIconField = createImageOverlay(g_currentModDirectory.."gui/hlm_field_normal.dds")
@@ -871,6 +873,10 @@ local function loadConfigWithImplement(spec, implementName)
 	return spec
 end
 
+local function isConfigImplement(implement)
+	return implement.spec_workArea ~= nil or implement.spec_combine ~= nil or implement.spec_forageWagon ~= nil or implement.spec_baler ~= nil
+end
+
 function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 	local spec = self.spec_HeadlandManagement
 	dbgprint("onPostAttachImplement : vehicle: "..self:getFullName(),2 )
@@ -883,9 +889,9 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 	dbgprint("onPostAttachImplement : frontNode: "..tostring(spec.frontNode), 2)
 	dbgprint("onPostAttachImplement : backNode: "..tostring(spec.backNode), 2)
 	-- try to load headland management configuration for added implement
-	if self:getIsActive() and self == g_currentMission.controlledVehicle and implement.getFullName ~= nil and not HeadlandManagement.isDedi then
+	if implement~= nil and implement.getFullName ~= nil and isConfigImplement(implement) and not HeadlandManagement.isDedi then
 		spec = loadConfigWithImplement(spec, implement:getFullName())
-		local sideInfo = SideNotification.new(); sideInfo:addNotification("configuration loaded for joint #"..tostring(jointDescIndex), {0,0,1,1}, 2000)
+		dbgprint("onPreDetachImplement : configuration loaded for implement "..tostring(implement:getFullName()), 2)
 	end
 	self.spec_HeadlandManagement = spec
 	self:raiseDirtyFlags(spec.dirtyFlag)
@@ -901,9 +907,9 @@ function HeadlandManagement:onPreDetachImplement(implement)
 	dbgprint("onPreDetachImplement : frontNode: "..tostring(spec.frontNode), 2)
 	dbgprint("onPreDetachImplement : backNode: "..tostring(spec.backNode), 2)
 	-- save headland management configuration for implement to be removed
-	if self:getIsActive() and self == g_currentMission.controlledVehicle and implement.getFullName ~= nil and not HeadlandManagement.isDedi then
+	if implement ~= nil and implement.object ~= nil and implement.object.getFullName ~= nil and isConfigImplement(implement.object) and not HeadlandManagement.isDedi then
 		saveConfigWithImplement(spec, implement.object:getFullName())
-		local sideInfo = SideNotification.new(); sideInfo:addNotification("configuration saved for implement "..tostring(implement.object:getFullName()), {0,1,0,1}, 2000)
+		dbgprint("onPreDetachImplement : configuration saved for implement "..tostring(implement.object:getFullName()), 2)
 	end
 	self.spec_HeadlandManagement = spec
 	self:raiseDirtyFlags(spec.dirtyFlag)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.4.2
+-- Version 2.9.5.0
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -892,6 +892,7 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 		if (isControlledVehicle or isControlledPlayer) and implement~= nil and implement.getFullName ~= nil and isConfigImplement(implement) and g_currentMission.isMissionStarted then
 			spec = loadConfigWithImplement(spec, implement:getFullName())
 			dbgprint("onPostAttachImplement : configuration loaded for implement "..tostring(implement:getFullName()), 2)
+			g_currentMission:addGameNotification("Configuration loaded for implement "..tostring(implement:getFullName(), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)
@@ -914,6 +915,7 @@ function HeadlandManagement:onPreDetachImplement(implement)
 		if (isControlledVehicle or isControlledPlayer) and implement ~= nil and implement.object ~= nil and implement.object.getFullName ~= nil and isConfigImplement(implement.object) then
 			saveConfigWithImplement(spec, implement.object:getFullName())
 			dbgprint("onPreDetachImplement : configuration saved for implement "..tostring(implement.object:getFullName()), 2)
+			g_currentMission:addGameNotification("Configuration saved for implement "..tostring(implement:getFullName(), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -851,7 +851,9 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 	dbgprint("onPostAttachImplement : vehicle: "..self:getFullName(),2 )
 	dbgprint("onPostAttachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)
 	dbgprint("onPostAttachImplement : implement: "..implement:getFullName(), 2)
-	spec = loadConfigWithImplement(spec, implement:getFullName())
+	if self:getIsActive() and self == g_currentMission.controlledVehicle and implement.getFullName ~= nil and not HeadlandManagement.isDedi then
+		spec = loadConfigWithImplement(spec, implement:getFullName())
+	end
 	-- Detect frontNode, backNode and recalculate vehicle length
 	spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(self)
 	spec.guidanceSteeringOffset = spec.vehicleLength
@@ -859,12 +861,15 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 	dbgprint("onPostAttachImplement : frontNode: "..tostring(spec.frontNode), 2)
 	dbgprint("onPostAttachImplement : backNode: "..tostring(spec.backNode), 2)
 	self.spec_HeadlandManagement = spec
+	self:raiseDirtyFlags(spec.dirtyFlag)
 end
 
 function HeadlandManagement:onPreDetachImplement(implement)
 	local spec = self.spec_HeadlandManagement
 	dbgprint("onPreDetachImplement : vehicle: "..self:getFullName(), 2)
-	saveConfigWithImplement(spec, implement.object:getFullName())
+	if self:getIsActive() and self == g_currentMission.controlledVehicle and implement.getFullName ~= nil and not HeadlandManagement.isDedi then
+		saveConfigWithImplement(spec, implement.object:getFullName())
+	end
 	-- Detect frontNode, backNode and recalculate vehicle length
 	spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(self, implement.object)
 	spec.guidanceSteeringOffset = spec.vehicleLength
@@ -872,6 +877,7 @@ function HeadlandManagement:onPreDetachImplement(implement)
 	dbgprint("onPreDetachImplement : frontNode: "..tostring(spec.frontNode), 2)
 	dbgprint("onPreDetachImplement : backNode: "..tostring(spec.backNode), 2)
 	self.spec_HeadlandManagement = spec
+	self:raiseDirtyFlags(spec.dirtyFlag)
 end
 
 local function getHeading(self)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -1245,6 +1245,7 @@ function HeadlandManagement:onUpdate(dt)
 		dbgprint("onUpdate : Field mode activated by back trigger (auto-resume)", 2)
 	end
 	
+	-- reset lastHeadland if no automatic field mode is active
 	if spec.lastHeadlandF and (not spec.autoResumeOnTrigger or spec.autoOverride) and not spec.isActive and not spec.headlandF and isOnField(self.rootNode) then 
 		spec.lastHeadlandF = false 
 		dbgprint("onUpdate: reset lastHeadlandF", 2)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -906,7 +906,8 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 		if (isControlledVehicle or isControlledPlayer) and implement~= nil and implement.getFullName ~= nil and implementType ~= nil and g_currentMission.isMissionStarted then
 			spec = loadConfigWithImplement(spec, implementType)
 			dbgprint("onPostAttachImplement : configuration loaded for implement type "..tostring(implementType), 2)
-			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration loaded for implement type "..tostring(implementType), "", 2500)
+			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeLoaded").." "..tostring(implementType), "", 2500)
+			--g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration loaded for implement type "..tostring(implementType), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)
@@ -930,7 +931,8 @@ function HeadlandManagement:onPreDetachImplement(implement)
 		if (isControlledVehicle or isControlledPlayer) and implement ~= nil and implement.object ~= nil and implement.object.getFullName ~= nil and implementType ~= nil then
 			saveConfigWithImplement(spec, implementType)
 			dbgprint("onPreDetachImplement : configuration saved for implement type "..tostring(implementType), 2)
-			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration saved for implement type "..tostring(implementType), "", 2500)
+			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeSaved").." "..tostring(implementType), "", 2500)
+			--g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration saved for implement type "..tostring(implementType), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.9
+-- Version 2.9.9.0
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -734,7 +734,7 @@ function HeadlandManagement:TOGGLESTATE(actionName, keyStatus, arg3, arg4, arg5)
 	if not spec.autoOverride and (spec.useHLMTriggerF or spec.useHLMTriggerB) and spec.isOn and (actionName == "HLM_AUTOOFF" or actionName == "HLM_TOGGLEAUTO") then
 		spec.autoOverride = true
 	-- anschalten nur wenn inaktiv
-	elseif spec.autoOverride and spec.isOn and (actionName == "HLM_AUTOON" or actionName == "HLM_TOGGLEAUTO") and spec.actStep == HeadlandManagement.MAXSTEP then
+	elseif spec.autoOverride and spec.isOn and (actionName == "HLM_AUTOON" or actionName == "HLM_TOGGLEAUTO") then
 		spec.autoOverride = false
 	end
 	

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.7
+-- Version 2.9.5.8
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node
@@ -906,7 +906,7 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 		if (isControlledVehicle or isControlledPlayer) and implement~= nil and implement.getFullName ~= nil and implementType ~= nil and g_currentMission.isMissionStarted then
 			spec = loadConfigWithImplement(spec, implementType)
 			dbgprint("onPostAttachImplement : configuration loaded for implement type "..tostring(implementType), 2)
-			g_currentMission:addGameNotification("", "Configuration loaded for implement type "..tostring(implementType), "", 2500)
+			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration loaded for implement type "..tostring(implementType), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)
@@ -930,7 +930,7 @@ function HeadlandManagement:onPreDetachImplement(implement)
 		if (isControlledVehicle or isControlledPlayer) and implement ~= nil and implement.object ~= nil and implement.object.getFullName ~= nil and implementType ~= nil then
 			saveConfigWithImplement(spec, implementType)
 			dbgprint("onPreDetachImplement : configuration saved for implement type "..tostring(implementType), 2)
-			g_currentMission:addGameNotification("", "Configuration saved for implement type "..tostring(implementType), "", 2500)
+			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration saved for implement type "..tostring(implementType), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -871,7 +871,20 @@ local function loadConfigWithImplement(spec, implementName)
 end
 
 local function isConfigImplement(implement)
-	return implement.spec_workArea ~= nil or implement.spec_combine ~= nil or implement.spec_forageWagon ~= nil or implement.spec_baler ~= nil
+	--return implement.spec_workArea ~= nil or implement.spec_combine ~= nil or implement.spec_forageWagon ~= nil or implement.spec_baler ~= nil
+	local returnType
+	
+	if implement.spec_plow ~= nil then returnType = "Plow"
+		elseif implement.spec_cultivator ~= nil then returnType = "Cultivator"
+		elseif implement.spec_roller ~= nil then returnType = "Roller"
+		elseif implement.spec_sowingMachine ~= nil then returnType = "Sowingmachine"
+		elseif implement.spec_mulcher ~= nil then returnType = "Mulcher"
+		elseif implement.spec_combine ~= nil then returnType = "Combine"
+		elseif implement.spec_forageWagon ~= nil then returnType = "Foragewagon"
+		elseif implement.spec_baler ~= nil then returnType = "Baler"
+	end
+	
+	return returnType
 end
 
 function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
@@ -889,10 +902,11 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 		-- try to load headland management configuration for added implement
 		local isControlledVehicle = g_currentMission.controlledVehicle ~= nil and self == g_currentMission.controlledVehicle -- w/o manual attach
 		local isControlledPlayer = g_currentMission.player ~= nil and g_currentMission.player.isControlled -- with manual attach
-		if (isControlledVehicle or isControlledPlayer) and implement~= nil and implement.getFullName ~= nil and isConfigImplement(implement) and g_currentMission.isMissionStarted then
-			spec = loadConfigWithImplement(spec, implement:getFullName())
-			dbgprint("onPostAttachImplement : configuration loaded for implement "..tostring(implement:getFullName()), 2)
-			g_currentMission:addGameNotification("Configuration loaded for implement "..tostring(implement:getFullName(), "", 2500)
+		local implementType = isConfigImplement(implement)
+		if (isControlledVehicle or isControlledPlayer) and implement~= nil and implement.getFullName ~= nil and implementType ~= nil and g_currentMission.isMissionStarted then
+			spec = loadConfigWithImplement(spec, implementType)
+			dbgprint("onPostAttachImplement : configuration loaded for implement type "..tostring(implementType), 2)
+			g_currentMission:addGameNotification("", "Configuration loaded for implement type "..tostring(implementType), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)
@@ -912,10 +926,11 @@ function HeadlandManagement:onPreDetachImplement(implement)
 		-- save headland management configuration for implement to be removed 
 		local isControlledVehicle = g_currentMission.controlledVehicle ~= nil and self == g_currentMission.controlledVehicle -- w/o manual attach
 		local isControlledPlayer = g_currentMission.player ~= nil and g_currentMission.player.isControlled -- with manual attach
-		if (isControlledVehicle or isControlledPlayer) and implement ~= nil and implement.object ~= nil and implement.object.getFullName ~= nil and isConfigImplement(implement.object) then
-			saveConfigWithImplement(spec, implement.object:getFullName())
-			dbgprint("onPreDetachImplement : configuration saved for implement "..tostring(implement.object:getFullName()), 2)
-			g_currentMission:addGameNotification("Configuration saved for implement "..tostring(implement:getFullName(), "", 2500)
+		local implementType = isConfigImplement(implement.object)
+		if (isControlledVehicle or isControlledPlayer) and implement ~= nil and implement.object ~= nil and implement.object.getFullName ~= nil and implementType ~= nil then
+			saveConfigWithImplement(spec, implementType)
+			dbgprint("onPreDetachImplement : configuration saved for implement type "..tostring(implementType), 2)
+			g_currentMission:addGameNotification("", "Configuration saved for implement type "..tostring(implementType), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.5
+-- Version 2.9.5.6
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node
@@ -1052,6 +1052,7 @@ function HeadlandManagement:onUpdate(dt)
 	then
 		spec.isActive = true
 		spec.lastHeadlandF = true
+		dbgprint("onUpdate : Headland mode activated by front trigger (auto-mode)", 2)
 	end
 	if self:getIsActive() and spec.exists and self == g_currentMission.controlledVehicle and not spec.isActive 
 		and spec.useHLMTriggerB and not spec.autoOverride
@@ -1059,6 +1060,7 @@ function HeadlandManagement:onUpdate(dt)
 	then
 		spec.isActive = true
 		spec.lastHeadlandB = true
+		dbgprint("onUpdate : Headland mode activated by back trigger (auto-mode)", 2)
 	end
 	
 	-- activate headland management at headland in auto-mode triggered by Guidance Steering
@@ -1066,6 +1068,7 @@ function HeadlandManagement:onUpdate(dt)
 		local gsSpec = self.spec_globalPositioningSystem
 		if not spec.isActive and gsSpec.playHeadLandWarning and not spec.autoOverride then
 			spec.isActive = true
+			dbgprint("onUpdate : Headland mode activated by guidance steering (auto-mode)", 2)
 		end
 	end
 
@@ -1170,10 +1173,17 @@ function HeadlandManagement:onUpdate(dt)
 	then
 		spec.actStep = -spec.actStep
 		spec.turnHeading = nil
+		dbgprint("onUpdate : Field mode activated by 180°-turn", 2)
 	end
 	
-	if (not spec.autoResumeOnTrigger or not spec.isActive) and not spec.headlandF and isOnField(self.rootNode) then spec.lastHeadlandF = false end
-	if (not spec.autoResumeOnTrigger or not spec.isActive) and not spec.headlandB and isOnField(self.rootNode) then spec.lastHeadlandB = false end
+	if (not spec.autoResumeOnTrigger or not spec.isActive) and not spec.headlandF and isOnField(self.rootNode) then 
+		spec.lastHeadlandF = false 
+		dbgprint("onUpdate: reset lastHeadlandF", 2)
+		end
+	if (not spec.autoResumeOnTrigger or not spec.isActive) and not spec.headlandB and isOnField(self.rootNode) then 
+		spec.lastHeadlandB = false 
+		dbgprint("onUpdate: reset lastHeadlandB", 2)
+		end
 	
 	-- auto resume on trigger: activate field mode when leaving headland in auto-mode
 	if self:getIsActive() and spec.exists and self == g_currentMission.controlledVehicle and spec.isActive and spec.actStep == HeadlandManagement.MAXSTEP 
@@ -1182,6 +1192,7 @@ function HeadlandManagement:onUpdate(dt)
 		spec.actStep = -spec.actStep
 		spec.turnHeading = nil
 		spec.lastHeadlandF = false
+		dbgprint("onUpdate : Field mode activated by front trigger (auto-resume)", 2)
 	end
 	if self:getIsActive() and spec.exists and self == g_currentMission.controlledVehicle and spec.isActive and spec.actStep == HeadlandManagement.MAXSTEP
 		and spec.useHLMTriggerB and spec.autoResumeOnTrigger and not spec.headlandB and spec.lastHeadlandB and isOnField(self.rootNode) and not spec.autoOverride
@@ -1189,6 +1200,7 @@ function HeadlandManagement:onUpdate(dt)
 		spec.actStep = -spec.actStep
 		spec.turnHeading = nil
 		spec.lastHeadlandB = false
+		dbgprint("onUpdate : Field mode activated by back trigger (auto-resume)", 2)
 	end
 end
 

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -757,12 +757,12 @@ function HeadlandManagement:guiCallback(changes, debug)
 	dbgprint_r(spec, 4, 2)
 end
 
-local function saveConfigToImplement(self, implement)
+local function saveConfigToImplement(self, implementName)
 	local spec = self.spec_HeadlandManagement
 	if spec ~= nil and spec.exists then
 		createFolder(HeadlandManagement.MODSETTINGSDIR)
 		
-		local filename = HeadlandManagement.MODSETTINGSDIR..implement:getFullName()
+		local filename = HeadlandManagement.MODSETTINGSDIR..implementName..".xml"
 		local key = "configSettings"
 		local xmlFile = XMLFile.create("configSettingsXML", filename, key)
 		
@@ -800,12 +800,12 @@ local function saveConfigToImplement(self, implement)
 	end
 end
 
-local function loadConfigToImplement(self, implement)
+local function loadConfigToImplement(self, implementName)
 	local spec = self.spec_HeadlandManagement
 	if spec ~= nil and spec.exists then
 		createFolder(HeadlandManagement.MODSETTINGSDIR)
 		
-		local filename = HeadlandManagement.MODSETTINGSDIR..implement:getFullName()
+		local filename = HeadlandManagement.MODSETTINGSDIR..implementName..".xml"
 		local key = "configSettings"
 		local xmlFile = XMLFile.loadIfExists("configSettingsXML", filename, key)
 		
@@ -847,7 +847,7 @@ end
 function HeadlandManagement.onPostAttachImplement(vehicle, implement, jointDescIndex)
 	local spec = vehicle.spec_HeadlandManagement
 	
-	loadConfigToImplement(vehicle, implement:object)
+	loadConfigToImplement(vehicle, implement:getFullName())
 	
 	dbgprint("onPostAttachImplement : vehicle: "..vehicle:getFullName(),2 )
 	dbgprint("onPostAttachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)
@@ -863,7 +863,7 @@ end
 function HeadlandManagement.onPreDetachImplement(vehicle, implement)
 	local spec = vehicle.spec_HeadlandManagement
 	
-	saveConfigToImplement(vehicle, implement.object)
+	saveConfigToImplement(vehicle, implement.object:getFullName())
 	
 	dbgprint("onPreDetachImplement : vehicle: "..vehicle:getFullName(), 2)
 	dbgprint("onPreDetachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -785,6 +785,7 @@ end
 local function saveConfigWithImplement(spec, implementName)
 	--local spec = self.spec_HeadlandManagement
 	dbgprint("saveConfigWithImplement : spec: "..tostring(spec), 2)
+	local saved = false
 	if spec ~= nil and spec.exists then
 		createFolder(HeadlandManagement.MODSETTINGSDIR)
 		
@@ -822,13 +823,16 @@ local function saveConfigWithImplement(spec, implementName)
 			xmlFile:save()
 			xmlFile:delete()
 			dbgprint("saveConfigWithImplement : saving data finished", 2)
+			saved = true
 		end
 	end
+	return saved
 end
 
 local function loadConfigWithImplement(spec, implementName)
 	--local spec = self.spec_HeadlandManagement
 	dbgprint("loadConfigWithImplement : spec: "..tostring(spec), 2)
+	local loaded = false
 	if spec ~= nil and spec.exists then
 		createFolder(HeadlandManagement.MODSETTINGSDIR)
 		
@@ -865,9 +869,10 @@ local function loadConfigWithImplement(spec, implementName)
 			
 			xmlFile:delete()
 			dbgprint("loadConfigToImplement : loading data finished", 2)
+			loaded = true
 		end
 	end
-	return spec
+	return spec, loaded
 end
 
 local function isConfigImplement(implement)
@@ -904,10 +909,12 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 		local isControlledPlayer = g_currentMission.player ~= nil and g_currentMission.player.isControlled -- with manual attach
 		local implementType = isConfigImplement(implement)
 		if (isControlledVehicle or isControlledPlayer) and implement~= nil and implement.getFullName ~= nil and implementType ~= nil and g_currentMission.isMissionStarted then
-			spec = loadConfigWithImplement(spec, implementType)
+			local loaded
+			spec, loaded = loadConfigWithImplement(spec, implementType)
 			dbgprint("onPostAttachImplement : configuration loaded for implement type "..tostring(implementType), 2)
-			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeLoaded").." "..g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_type_"..implementType), "", 2500)
-			--g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration loaded for implement type "..tostring(implementType), "", 2500)
+			if loaded then
+				g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeLoaded").." "..g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_type_"..implementType), "", 2500)
+			end
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)
@@ -929,10 +936,11 @@ function HeadlandManagement:onPreDetachImplement(implement)
 		local isControlledPlayer = g_currentMission.player ~= nil and g_currentMission.player.isControlled -- with manual attach
 		local implementType = isConfigImplement(implement.object)
 		if (isControlledVehicle or isControlledPlayer) and implement ~= nil and implement.object ~= nil and implement.object.getFullName ~= nil and implementType ~= nil then
-			saveConfigWithImplement(spec, implementType)
+			local saved = saveConfigWithImplement(spec, implementType)
 			dbgprint("onPreDetachImplement : configuration saved for implement type "..tostring(implementType), 2)
-			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeSaved").." "..g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_type_"..implementType), "", 2500)
-			--g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration saved for implement type "..tostring(implementType), "", 2500)
+			if saved then
+				g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeSaved").." "..g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_type_"..implementType), "", 2500)
+			end
 		end
 		self.spec_HeadlandManagement = spec
 		self:raiseDirtyFlags(spec.dirtyFlag)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.9.0
+-- Version 2.1.0.0 RC0
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node
@@ -13,8 +13,7 @@
 -- Turn Headland Management on/off
 -- Option to temporary disable headland automatic by key
 -- Auto-Resume if trigger leaves headland area
-
--- WIP: Save configuration locally by implement
+-- Save configuration locally with implement-type
  
 HeadlandManagement = {}
 

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -906,7 +906,7 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 		if (isControlledVehicle or isControlledPlayer) and implement~= nil and implement.getFullName ~= nil and implementType ~= nil and g_currentMission.isMissionStarted then
 			spec = loadConfigWithImplement(spec, implementType)
 			dbgprint("onPostAttachImplement : configuration loaded for implement type "..tostring(implementType), 2)
-			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeLoaded").." "..tostring(implementType), "", 2500)
+			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeLoaded").." "..g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_type_"..implementType), "", 2500)
 			--g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration loaded for implement type "..tostring(implementType), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec
@@ -931,7 +931,7 @@ function HeadlandManagement:onPreDetachImplement(implement)
 		if (isControlledVehicle or isControlledPlayer) and implement ~= nil and implement.object ~= nil and implement.object.getFullName ~= nil and implementType ~= nil then
 			saveConfigWithImplement(spec, implementType)
 			dbgprint("onPreDetachImplement : configuration saved for implement type "..tostring(implementType), 2)
-			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeSaved").." "..tostring(implementType), "", 2500)
+			g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_implementTypeSaved").." "..g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_type_"..implementType), "", 2500)
 			--g_currentMission:addGameNotification(g_i18n.modEnvironments[HeadlandManagement.MOD_NAME]:getText("text_HLM_configuration"), "Configuration saved for implement type "..tostring(implementType), "", 2500)
 		end
 		self.spec_HeadlandManagement = spec

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -1245,14 +1245,14 @@ function HeadlandManagement:onUpdate(dt)
 		dbgprint("onUpdate : Field mode activated by back trigger (auto-resume)", 2)
 	end
 	
-	--if spec.lastHeadlandF and (not spec.autoResumeOnTrigger or not spec.isActive) and not spec.headlandF and isOnField(self.rootNode) then 
---		spec.lastHeadlandF = false 
---		dbgprint("onUpdate: reset lastHeadlandF", 2)
---	end
---	if spec.lastHeadlandB and (not spec.autoResumeOnTrigger or not spec.isActive) and not spec.headlandB and isOnField(self.rootNode) then 
---		spec.lastHeadlandB = false 
---		dbgprint("onUpdate: reset lastHeadlandB", 2)
---	end
+	if spec.lastHeadlandF and (not spec.autoResumeOnTrigger or spec.autoOverride) and not spec.isActive and not spec.headlandF and isOnField(self.rootNode) then 
+		spec.lastHeadlandF = false 
+		dbgprint("onUpdate: reset lastHeadlandF", 2)
+	end
+	if spec.lastHeadlandB and (not spec.autoResumeOnTrigger or spec.autoOverride) and not spec.isActive and not spec.headlandB and isOnField(self.rootNode) then 
+		spec.lastHeadlandB = false 
+		dbgprint("onUpdate: reset lastHeadlandB", 2)
+	end
 end
 
 function HeadlandManagement:onDraw(dt)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -1278,6 +1278,7 @@ function HeadlandManagement:onDraw(dt)
 		
 		local headlandAutomaticGS = (spec.modGuidanceSteeringFound and spec.useGuidanceSteeringTrigger) 
 		local headlandAutomatic	= not spec.autoOverride and (spec.useHLMTriggerF or spec.useHLMTriggerB)
+		local headlandAutomaticResume = spec.autoResume and not spec.autoOverride
 				
 		-- field mode
 		if spec.isOn and headlandAutomatic and not spec.isActive then 
@@ -1309,11 +1310,11 @@ function HeadlandManagement:onDraw(dt)
 		end
 	
 		-- headland mode			
-		if spec.isOn and spec.autoResume and spec.isActive and spec.actStep==HeadlandManagement.MAXSTEP then
+		if spec.isOn and headlandAutomaticResume and spec.isActive and spec.actStep==HeadlandManagement.MAXSTEP then
 			guiIcon = HeadlandManagement.guiIconHeadlandA
 		end
 		
-		if spec.isOn and not spec.autoResume and spec.isActive and spec.actStep==HeadlandManagement.MAXSTEP then 
+		if spec.isOn and not headlandAutomaticResume and spec.isActive and spec.actStep==HeadlandManagement.MAXSTEP then 
 			guiIcon = HeadlandManagement.guiIconHeadland
 		end	
 		

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -759,6 +759,7 @@ end
 
 local function saveConfigWithImplement(spec, implementName)
 	--local spec = self.spec_HeadlandManagement
+	dbgprint("saveConfigWithImplement : spec: "..tostring(spec), 2)
 	if spec ~= nil and spec.exists then
 		createFolder(HeadlandManagement.MODSETTINGSDIR)
 		
@@ -800,8 +801,9 @@ local function saveConfigWithImplement(spec, implementName)
 	end
 end
 
-local function loadConfigToImplement(spec, implementName)
+local function loadConfigWithImplement(spec, implementName)
 	--local spec = self.spec_HeadlandManagement
+	dbgprint("loadConfigWithImplement : spec: "..tostring(spec), 2)
 	if spec ~= nil and spec.exists then
 		createFolder(HeadlandManagement.MODSETTINGSDIR)
 		
@@ -812,31 +814,30 @@ local function loadConfigToImplement(spec, implementName)
 		if xmlFile ~= nil then 
 			dbgprint("loadConfigToImplement : key: "..tostring(key), 2)
 
-			xmlFile:getFloat(key..".turnSpeed", spec.turnSpeed)
-			xmlFile:getBool(key..".useSpeedControl", spec.useSpeedControl)
-			xmlFile:getBool(key..".useModSpeedControl", spec.useModSpeedControl)
-			xmlFile:getBool(key..".useCrabSteering", spec.useCrabSteering)
-			xmlFile:getBool(key..".useCrabSteeringTwoStep", spec.useCrabSteeringTwoStep)
-			xmlFile:getBool(key..".useRaiseImplementF", spec.useRaiseImplementF)
-			xmlFile:getBool(key..".useRaiseImplementB", spec.useRaiseImplementB)
-			xmlFile:getBool(key..".waitOnTrigger", spec.waitOnTrigger)
-			xmlFile:getBool(key..".useStopPTOF", spec.useStopPTOF)
-			xmlFile:getBool(key..".useStopPTOB", spec.useStopPTOB)
-			xmlFile:getBool(key..".turnPlow", spec.useTurnPlow)
-			xmlFile:getBool(key..".centerPlow", spec.useCenterPlow)
-			xmlFile:getBool(key..".switchRidge", spec.useRidgeMarker)
-			xmlFile:getBool(key..".useGPS", spec.useGPS)
-			xmlFile:getInt(key..".gpsSetting", spec.gpsSetting)
-			xmlFile:getBool(key..".useGuidanceSteeringTrigger", spec.useGuidanceSteeringTrigger)
-			xmlFile:getBool(key..".useGuidanceSteeringOffget", spec.useGuidanceSteeringOffget)
-			xmlFile:getBool(key..".useHLMTriggerF", spec.useHLMTriggerF)
-			xmlFile:getBool(key..".useHLMTriggerB", spec.useHLMTriggerB)
-			xmlFile:getInt(key..".headlandDistance", spec.headlandDistance)
-			xmlFile:getBool(key..".vcaDirSwitch", spec.vcaDirSwitch)
-			xmlFile:getBool(key..".autoResume", spec.autoResume)
-			xmlFile:getBool(key..".useDiffLock", spec.useDiffLock)
+			spec.turnSpeed = xmlFile:getFloat(key..".turnSpeed")
+			spec.useSpeedControl = xmlFile:getBool(key..".useSpeedControl")
+			spec.useModSpeedControl = xmlFile:getBool(key..".useModSpeedControl")
+			spec.useCrabSteering = xmlFile:getBool(key..".useCrabSteering")
+			spec.useCrabSteeringTwoStep = xmlFile:getBool(key..".useCrabSteeringTwoStep")
+			spec.useRaiseImplementF = xmlFile:getBool(key..".useRaiseImplementF")
+			spec.useRaiseImplementB = xmlFile:getBool(key..".useRaiseImplementB")
+			spec.waitOnTrigger = xmlFile:getBool(key..".waitOnTrigger")
+			spec.useStopPTOF = xmlFile:getBool(key..".useStopPTOF")
+			spec.useStopPTOB = xmlFile:getBool(key..".useStopPTOB")
+			spec.useTurnPlow = xmlFile:getBool(key..".turnPlow")
+			spec.useCenterPlow = xmlFile:getBool(key..".centerPlow")
+			spec.useRidgeMarker = xmlFile:getBool(key..".switchRidge")
+			spec.useGPS = xmlFile:getBool(key..".useGPS")
+			spec.gpsSetting = xmlFile:getInt(key..".gpsSetting")
+			spec.useGuidanceSteeringTrigger = xmlFile:getBool(key..".useGuidanceSteeringTrigger")
+			spec.useGuidanceSteeringOffget = xmlFile:getBool(key..".useGuidanceSteeringOffget")
+			spec.useHLMTriggerF = xmlFile:getBool(key..".useHLMTriggerF")
+			spec.useHLMTriggerB = xmlFile:getBool(key..".useHLMTriggerB")
+			spec.headlandDistance = xmlFile:getInt(key..".headlandDistance")
+			spec.vcaDirSwitch = xmlFile:getBool(key..".vcaDirSwitch")
+			spec.autoResume = xmlFile:getBool(key..".autoResume")
+			spec.useDiffLock = xmlFile:getBool(key..".useDiffLock")
 			
-			xmlFile:save()
 			xmlFile:delete()
 			dbgprint("loadConfigToImplement : loading data finished", 2)
 		end
@@ -845,35 +846,32 @@ local function loadConfigToImplement(spec, implementName)
 end
 
 -- Calculate implement reference node
-function HeadlandManagement.onPostAttachImplement(vehicle, implement, jointDescIndex)
-	local spec = vehicle.spec_HeadlandManagement
-	
-	spec = loadConfigWithImplement(spec, implement:getFullName())
-	
-	dbgprint("onPostAttachImplement : vehicle: "..vehicle:getFullName(),2 )
+function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
+	local spec = self.spec_HeadlandManagement
+	dbgprint("onPostAttachImplement : vehicle: "..self:getFullName(),2 )
 	dbgprint("onPostAttachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)
 	dbgprint("onPostAttachImplement : implement: "..implement:getFullName(), 2)
+	spec = loadConfigWithImplement(spec, implement:getFullName())
 	-- Detect frontNode, backNode and recalculate vehicle length
-	spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(vehicle)
+	spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(self)
 	spec.guidanceSteeringOffset = spec.vehicleLength
 	dbgprint("onPostAttachImplement : length: "..tostring(spec.vehicleLength), 2)
 	dbgprint("onPostAttachImplement : frontNode: "..tostring(spec.frontNode), 2)
 	dbgprint("onPostAttachImplement : backNode: "..tostring(spec.backNode), 2)
+	self.spec_HeadlandManagement = spec
 end
 
-function HeadlandManagement.onPreDetachImplement(vehicle, implement)
-	local spec = vehicle.spec_HeadlandManagement
-	
+function HeadlandManagement:onPreDetachImplement(implement)
+	local spec = self.spec_HeadlandManagement
+	dbgprint("onPreDetachImplement : vehicle: "..self:getFullName(), 2)
 	saveConfigWithImplement(spec, implement.object:getFullName())
-	
-	dbgprint("onPreDetachImplement : vehicle: "..vehicle:getFullName(), 2)
-	dbgprint("onPreDetachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)
 	-- Detect frontNode, backNode and recalculate vehicle length
-	spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(vehicle, implement.object)
+	spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(self, implement.object)
 	spec.guidanceSteeringOffset = spec.vehicleLength
 	dbgprint("onPreDetachImplement : length: "..tostring(spec.vehicleLength), 2)
 	dbgprint("onPreDetachImplement : frontNode: "..tostring(spec.frontNode), 2)
 	dbgprint("onPreDetachImplement : backNode: "..tostring(spec.backNode), 2)
+	self.spec_HeadlandManagement = spec
 end
 
 local function getHeading(self)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -878,6 +878,13 @@ local function isConfigImplement(implement)
 end
 
 function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
+
+	local player = g_currentMission.player
+	if player ~= nil then
+		dbgprint("onPostAttachImplement : playerdata : isOwner: "..tostring(player.isOwner), 2)
+		dbgprint("onPostAttachImplement : playerdata : isControlled: "..tostring(player.isControlled), 2)
+	end
+
 	local spec = self.spec_HeadlandManagement
 	dbgprint("onPostAttachImplement : vehicle: "..self:getFullName(),2 )
 	dbgprint("onPostAttachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)
@@ -898,6 +905,13 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 end
 
 function HeadlandManagement:onPreDetachImplement(implement)
+
+	local player = g_currentMission.player
+	if player ~= nil then
+		dbgprint("onPreDetachImplement : playerdata : isOwner: "..tostring(player.isOwner), 2)
+		dbgprint("onPreDetachImplement : playerdata : isControlled: "..tostring(player.isControlled), 2)
+	end
+	
 	local spec = self.spec_HeadlandManagement
 	dbgprint("onPreDetachImplement : vehicle: "..self:getFullName(), 2)
 	-- Detect frontNode, backNode and recalculate vehicle length

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -757,8 +757,8 @@ function HeadlandManagement:guiCallback(changes, debug)
 	dbgprint_r(spec, 4, 2)
 end
 
-local function saveConfigToImplement(self, implementName)
-	local spec = self.spec_HeadlandManagement
+local function saveConfigWithImplement(spec, implementName)
+	--local spec = self.spec_HeadlandManagement
 	if spec ~= nil and spec.exists then
 		createFolder(HeadlandManagement.MODSETTINGSDIR)
 		
@@ -795,13 +795,13 @@ local function saveConfigToImplement(self, implementName)
 			
 			xmlFile:save()
 			xmlFile:delete()
-			dbgprint("saveConfigToImplement : saving data finished", 2)
+			dbgprint("saveConfigWithImplement : saving data finished", 2)
 		end
 	end
 end
 
-local function loadConfigToImplement(self, implementName)
-	local spec = self.spec_HeadlandManagement
+local function loadConfigToImplement(spec, implementName)
+	--local spec = self.spec_HeadlandManagement
 	if spec ~= nil and spec.exists then
 		createFolder(HeadlandManagement.MODSETTINGSDIR)
 		
@@ -841,13 +841,14 @@ local function loadConfigToImplement(self, implementName)
 			dbgprint("loadConfigToImplement : loading data finished", 2)
 		end
 	end
+	return spec
 end
 
 -- Calculate implement reference node
 function HeadlandManagement.onPostAttachImplement(vehicle, implement, jointDescIndex)
 	local spec = vehicle.spec_HeadlandManagement
 	
-	loadConfigToImplement(vehicle, implement:getFullName())
+	spec = loadConfigWithImplement(spec, implement:getFullName())
 	
 	dbgprint("onPostAttachImplement : vehicle: "..vehicle:getFullName(),2 )
 	dbgprint("onPostAttachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)
@@ -863,7 +864,7 @@ end
 function HeadlandManagement.onPreDetachImplement(vehicle, implement)
 	local spec = vehicle.spec_HeadlandManagement
 	
-	saveConfigToImplement(vehicle, implement.object:getFullName())
+	saveConfigWithImplement(spec, implement.object:getFullName())
 	
 	dbgprint("onPreDetachImplement : vehicle: "..vehicle:getFullName(), 2)
 	dbgprint("onPreDetachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.3
+-- Version 2.9.5.4
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node
@@ -415,18 +415,6 @@ function HeadlandManagement:onPostLoad(savegame)
 	
 	-- Check if Mod GuidanceSteering exists
 	spec.modGuidanceSteeringFound = self.spec_globalPositioningSystem ~= nil and not HeadlandManagement.kbGS
-	
-	-- Detect frontNode, backNode and calculate vehicle length and width
-	spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(self)
-	spec.guidanceSteeringOffset = spec.vehicleLength
-	--spec.maxTurningRadius = self.maxTurningRadius
-	if self.spec_workArea ~= nil then
-		dbgprint_r(self.spec_workArea, 1, 2)
-	end
-	
-	dbgprint("onPostLoad : length: "..tostring(spec.vehicleLength), 1)
-	dbgprint("onPostLoad : frontNode: "..tostring(spec.frontNode), 2)
-	dbgprint("onPostLoad : backNode: "..tostring(spec.backNode), 2)
 
 	-- Check if Mod VCA exists
 	spec.modVCAFound = self.vcaSetState ~= nil and not HeadlandManagement.kbVCA
@@ -475,6 +463,15 @@ function HeadlandManagement:onPostLoad(savegame)
 	if spec.gpsSetting > 2 and not spec.modVCAFound then spec.gpsSetting = 1 end
 	
 	spec.autoResumeOnTrigger = spec.autoResume and (spec.useHLMTriggerF or spec.useHLMTriggerB)
+	
+	if spec.exists then
+		-- Detect frontNode, backNode and calculate vehicle length and width
+		spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(self)
+		spec.guidanceSteeringOffset = spec.vehicleLength
+		dbgprint("onPostLoad : length: "..tostring(spec.vehicleLength), 1)
+		dbgprint("onPostLoad : frontNode: "..tostring(spec.frontNode), 2)
+		dbgprint("onPostLoad : backNode: "..tostring(spec.backNode), 2)
+	end
 	
 	-- Set HLM configuration if set by savegame
 	self.configurations["HeadlandManagement"] = spec.exists and 2 or 1
@@ -885,8 +882,8 @@ local function isConfigImplement(implement)
 end
 
 function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
-	if not HeadlandManagement.isDedi then
-		local spec = self.spec_HeadlandManagement
+	local spec = self.spec_HeadlandManagement
+	if spec.exists and not HeadlandManagement.isDedi then
 		dbgprint("onPostAttachImplement : vehicle: "..self:getFullName(),2 )
 		dbgprint("onPostAttachImplement : jointDescIndex: "..tostring(jointDescIndex), 2)
 		dbgprint("onPostAttachImplement : implement: "..implement:getFullName(), 2)
@@ -909,8 +906,8 @@ function HeadlandManagement:onPostAttachImplement(implement, jointDescIndex)
 end
 
 function HeadlandManagement:onPreDetachImplement(implement)
-	if not HeadlandManagement.isDedi then
-		local spec = self.spec_HeadlandManagement
+	local spec = self.spec_HeadlandManagement
+	if spec.exists and not HeadlandManagement.isDedi then
 		dbgprint("onPreDetachImplement : vehicle: "..self:getFullName(), 2)
 		-- Detect frontNode, backNode and recalculate vehicle length
 		spec.frontNode, spec.backNode, spec.vehicleLength, spec.vehicleWidth, spec.maxTurningRadius = vehicleMeasurement(self, implement.object)

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.6
+-- Version 2.9.5.7
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node
@@ -43,10 +43,6 @@ HeadlandManagement.STOPGPS = 11
 HeadlandManagement.MAXSTEP = 12
 
 HeadlandManagement.debug = false
-
-dbgprint("isDedi: "..tostring(HeadlandManagement.isDedi), 1)
-dbgprint("g_server: "..tostring(g_server), 2)
-dbgprint("g_currentMission: "..tostring(g_currentMission), 2)
 
 HeadlandManagement.BEEPSOUND = createSample("HLMBEEP")
 loadSample(HeadlandManagement.BEEPSOUND, g_currentModDirectory.."sound/beep.ogg", false)
@@ -191,8 +187,6 @@ function HeadlandManagement:onLoad(savegame)
 	
 	local spec = self.spec_HeadlandManagement
 	spec.dirtyFlag = self:getNextDirtyFlag()
-	
-	spec.actionEventOn = nil
 	
 	spec.exists = false				-- Headland Management is configured into vehicle
 	spec.isOn = false				-- Headland Management is switched on
@@ -1183,7 +1177,6 @@ function HeadlandManagement:onUpdate(dt)
 	then
 		spec.actStep = -spec.actStep
 		spec.turnHeading = nil
-		--spec.lastHeadlandF = false
 		dbgprint("onUpdate : Field mode activated by front trigger (auto-resume)", 2)
 	end
 	if not HeadlandManagement.isDedi and self:getIsActive() and spec.exists and self == g_currentMission.controlledVehicle and spec.isActive and spec.actStep == HeadlandManagement.MAXSTEP
@@ -1191,7 +1184,6 @@ function HeadlandManagement:onUpdate(dt)
 	then
 		spec.actStep = -spec.actStep
 		spec.turnHeading = nil
-		--spec.lastHeadlandB = false
 		dbgprint("onUpdate : Field mode activated by back trigger (auto-resume)", 2)
 	end
 	

--- a/headlandManagement.lua
+++ b/headlandManagement.lua
@@ -2,7 +2,7 @@
 -- Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede
--- Version 2.9.5.4
+-- Version 2.9.5.5
 --
 -- Make Headland Detection independent from other mods like GS
 -- Two nodes: front node + back node
@@ -735,7 +735,7 @@ function HeadlandManagement:TOGGLESTATE(actionName, keyStatus, arg3, arg4, arg5)
 	end
 	-- headland automatic
 	-- abschalten nur wenn aktiv
-	if not spec.autoOverride and (spec.useHLMTriggerF or spec.useHLMTriggerB) and spec.isOn and (actionName == "HLM_AUTOOFF" or actionName == "HLM_TOGGLEAUTO") then
+	if not spec.autoOverride and (spec.useHLMTriggerF or spec.useHLMTriggerB or spec.useGuidanceSteeringTrigger) and spec.isOn and (actionName == "HLM_AUTOOFF" or actionName == "HLM_TOGGLEAUTO") then
 		spec.autoOverride = true
 	-- anschalten nur wenn inaktiv
 	elseif spec.autoOverride and spec.isOn and (actionName == "HLM_AUTOON" or actionName == "HLM_TOGGLEAUTO") then
@@ -1064,7 +1064,7 @@ function HeadlandManagement:onUpdate(dt)
 	-- activate headland management at headland in auto-mode triggered by Guidance Steering
 	if self:getIsActive() and spec.exists and self == g_currentMission.controlledVehicle and spec.modGuidanceSteeringFound and spec.useGuidanceSteeringTrigger then
 		local gsSpec = self.spec_globalPositioningSystem
-		if not spec.isActive and gsSpec.playHeadLandWarning then
+		if not spec.isActive and gsSpec.playHeadLandWarning and not spec.autoOverride then
 			spec.isActive = true
 		end
 	end
@@ -1166,7 +1166,7 @@ function HeadlandManagement:onUpdate(dt)
 	
 	-- auto resume on turn (180 degrees)
 	if self:getIsActive() and spec.exists and self == g_currentMission.controlledVehicle and spec.isActive and spec.actStep == HeadlandManagement.MAXSTEP
-		and spec.autoResume and not spec.autoResumeOnTrigger and spec.heading == spec.turnHeading 
+		and spec.autoResume and not spec.autoOverride and not spec.autoResumeOnTrigger and spec.heading == spec.turnHeading 
 	then
 		spec.actStep = -spec.actStep
 		spec.turnHeading = nil

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.5.7
+-- Version 2.9.5.8
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.9.0
+-- Version 2.1.0.0 RC0
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.5.0
+-- Version 2.9.5.2
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.5.6
+-- Version 2.9.5.7
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.5.3
+-- Version 2.9.5.5
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.5.5
+-- Version 2.9.5.6
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.5.2
+-- Version 2.9.5.3
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.4.2
+-- Version 2.9.5.0
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.5.8
+-- Version 2.9.5.9
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/headlandManagementRegister.lua
+++ b/headlandManagementRegister.lua
@@ -2,7 +2,7 @@
 -- Register Headland Management for LS 22
 --
 -- Jason06 / Glowins Modschmiede 
--- Version 2.9.5.9
+-- Version 2.9.9.0
 --
 
 if g_specializationManager:getSpecializationByName("HeadlandManagement") == nil then

--- a/l10n/l10n_cz.xml
+++ b/l10n/l10n_cz.xml
@@ -16,6 +16,8 @@
 		<text name="text_HLM_notInstalled" text="Souvraťový management není nainstalován"/>
 		<text name="text_HLM_installed_short" text="Instalováno"/>
 		<text name="text_HLM_notInstalled_short" text="Není Instalováno"/>
+		<text name="text_HLM_implementTypeLoaded" text="Configuration loaded for implement type"/>
+		<text name="text_HLM_implementTypeSaved" text="Configuration saved for implement type"/>
 
 		<text name="text_HLM_type_Plow" text="Plow"/>
 		<text name="text_HLM_type_Cultivator" text="Cultivator"/>

--- a/l10n/l10n_cz.xml
+++ b/l10n/l10n_cz.xml
@@ -17,6 +17,15 @@
 		<text name="text_HLM_installed_short" text="Instalováno"/>
 		<text name="text_HLM_notInstalled_short" text="Není Instalováno"/>
 
+		<text name="text_HLM_type_Plow" text="Plow"/>
+		<text name="text_HLM_type_Cultivator" text="Cultivator"/>
+		<text name="text_HLM_type_Roller" text="Roller"/>
+		<text name="text_HLM_type_Sowingmachine" text="Sowingmachine"/>
+		<text name="text_HLM_type_Mulcher" text="Mulcher"/>
+		<text name="text_HLM_type_Combine" text="Combine"/>
+		<text name="text_HLM_type_Foragewagon" text="Foragewagon"/>
+		<text name="text_HLM_type_Baler" text="Baler"/>
+		
 		<text name="hlmgui_title" text="Souvraťový management: Nastavení pro "/>
 		<text name="hlmgui_on" text="Zap."/>
 		<text name="hlmgui_off" text="Vyp."/>

--- a/l10n/l10n_cz.xml
+++ b/l10n/l10n_cz.xml
@@ -6,6 +6,9 @@
     	<text name="input_HLM_SWITCHOFF" text="Režim pole" />	
     	<text name="input_HLM_SHOWGUI" text="Souvratě: Nastavení" />
     	<text name="input_HLM_MAINSWITCH" text="HLM: Switch on/off"/>
+		<text name="input_HLM_TOGGLEAUTO" text="HLM: Toggle headland automatic"/>
+		<text name="input_HLM_AUTOON" text="HLM: Turn on headland automatic"/>
+		<text name="input_HLM_AUTOOFF" text="HLM: Turn off headland automatic"/>
 		
 		<text name="text_HLM_isActive" text="Souvratě: Mod aktivní"/>
 		<text name="text_HLM_configuration" text="Souvraťový management"/>

--- a/l10n/l10n_de.xml
+++ b/l10n/l10n_de.xml
@@ -16,8 +16,8 @@
 		<text name="text_HLM_notInstalled" text="Kein Vorgewende-Management eingebaut"/>
 		<text name="text_HLM_installed_short" text="Eingebaut"/>
 		<text name="text_HLM_notInstalled_short" text="Nicht eingebaut"/>
-		<text name="text_HLM_configuration" text="Konfiguration geladen für den Gerätetyp">
-		<text name="text_HLM_configuration" text="Konfiguration gespeichert für den Gerätetyp">
+		<text name="text_HLM_configuration" text="Konfiguration geladen für den Gerätetyp"/>
+		<text name="text_HLM_configuration" text="Konfiguration gespeichert für den Gerätetyp"/>
 		
 		<text name="text_HLM_type_Plow" text="Pflug"/>
 		<text name="text_HLM_type_Cultivator" text="Grubber"/>

--- a/l10n/l10n_de.xml
+++ b/l10n/l10n_de.xml
@@ -16,8 +16,8 @@
 		<text name="text_HLM_notInstalled" text="Kein Vorgewende-Management eingebaut"/>
 		<text name="text_HLM_installed_short" text="Eingebaut"/>
 		<text name="text_HLM_notInstalled_short" text="Nicht eingebaut"/>
-		<text name="text_HLM_configuration" text="Konfiguration geladen für den Gerätetyp"/>
-		<text name="text_HLM_configuration" text="Konfiguration gespeichert für den Gerätetyp"/>
+		<text name="text_HLM_implementTypeLoaded" text="Konfiguration geladen für den Gerätetyp"/>
+		<text name="text_HLM_implementTypeSaved" text="Konfiguration gespeichert für den Gerätetyp"/>
 		
 		<text name="text_HLM_type_Plow" text="Pflug"/>
 		<text name="text_HLM_type_Cultivator" text="Grubber"/>

--- a/l10n/l10n_de.xml
+++ b/l10n/l10n_de.xml
@@ -6,6 +6,9 @@
     	<text name="input_HLM_SWITCHOFF" text="Feld-Modus" />	
     	<text name="input_HLM_SHOWGUI" text="HLM: Einstellungen" />
     	<text name="input_HLM_MAINSWITCH" text="HLM: An-/ Ausschalten"/>
+		<text name="input_HLM_TOGGLEAUTO" text="HLM: Vorgewendeautomatik umschalten"/>
+		<text name="input_HLM_AUTOON" text="HLM: Vorgewendeautomatik einschalten"/>
+		<text name="input_HLM_AUTOOFF" text="HLM: Vorgewendeautomatik ausschalten"/>
 
 		<text name="text_HLM_isActive" text="Vorgewende-Modus aktiv"/>
 		<text name="text_HLM_configuration" text="Vorgewende-Management"/>

--- a/l10n/l10n_de.xml
+++ b/l10n/l10n_de.xml
@@ -16,6 +16,17 @@
 		<text name="text_HLM_notInstalled" text="Kein Vorgewende-Management eingebaut"/>
 		<text name="text_HLM_installed_short" text="Eingebaut"/>
 		<text name="text_HLM_notInstalled_short" text="Nicht eingebaut"/>
+		<text name="text_HLM_configuration" text="Konfiguration geladen für den Gerätetyp">
+		<text name="text_HLM_configuration" text="Konfiguration gespeichert für den Gerätetyp">
+		
+		<text name="text_HLM_type_Plow" text="Pflug"/>
+		<text name="text_HLM_type_Cultivator" text="Grubber"/>
+		<text name="text_HLM_type_Roller" text="Walze"/>
+		<text name="text_HLM_type_Sowingmachine" text="Sähmaschine"/>
+		<text name="text_HLM_type_Mulcher" text="Mulcher"/>
+		<text name="text_HLM_type_Combine" text="Erntemaschine"/>
+		<text name="text_HLM_type_Foragewagon" text="Ladewagen"/>
+		<text name="text_HLM_type_Baler" text="Ballenpresse"/>
 
 		<text name="hlmgui_title" text="Vorgewende-Management (HLM): Konfiguration für "/>
 		<text name="hlmgui_on" text="an"/>

--- a/l10n/l10n_en.xml
+++ b/l10n/l10n_en.xml
@@ -16,8 +16,8 @@
 		<text name="text_HLM_notInstalled" text="Headlandmanagement not installed"/>
 		<text name="text_HLM_installed_short" text="Installed"/>
 		<text name="text_HLM_notInstalled_short" text="Not installed"/>
-		<text name="text_HLM_implementTypeLoaded" text="Configuration loaded for implement type">
-		<text name="text_HLM_implementTypeSaved" text="Configuration saved for implement type">
+		<text name="text_HLM_implementTypeLoaded" text="Configuration loaded for implement type"/>
+		<text name="text_HLM_implementTypeSaved" text="Configuration saved for implement type"/>
 
 		<text name="text_HLM_type_Plow" text="Plow"/>
 		<text name="text_HLM_type_Cultivator" text="Cultivator"/>

--- a/l10n/l10n_en.xml
+++ b/l10n/l10n_en.xml
@@ -16,7 +16,18 @@
 		<text name="text_HLM_notInstalled" text="Headlandmanagement not installed"/>
 		<text name="text_HLM_installed_short" text="Installed"/>
 		<text name="text_HLM_notInstalled_short" text="Not installed"/>
+		<text name="text_HLM_implementTypeLoaded" text="Configuration loaded for implement type">
+		<text name="text_HLM_implementTypeSaved" text="Configuration saved for implement type">
 
+		<text name="text_HLM_type_Plow" text="Plow"/>
+		<text name="text_HLM_type_Cultivator" text="Cultivator"/>
+		<text name="text_HLM_type_Roller" text="Roller"/>
+		<text name="text_HLM_type_Sowingmachine" text="Sowingmachine"/>
+		<text name="text_HLM_type_Mulcher" text="Mulcher"/>
+		<text name="text_HLM_type_Combine" text="Combine"/>
+		<text name="text_HLM_type_Foragewagon" text="Foragewagon"/>
+		<text name="text_HLM_type_Baler" text="Baler"/>
+		
 		<text name="hlmgui_title" text="Headlandmanagement (HLM): Settings for "/>
 		<text name="hlmgui_on" text="on"/>
 		<text name="hlmgui_off" text="off"/>

--- a/l10n/l10n_en.xml
+++ b/l10n/l10n_en.xml
@@ -6,6 +6,9 @@
     	<text name="input_HLM_SWITCHOFF" text="Field-Mode" />	
     	<text name="input_HLM_SHOWGUI" text="Headland: Settings" />
     	<text name="input_HLM_MAINSWITCH" text="HLM: Switch on/off"/>
+		<text name="input_HLM_TOGGLEAUTO" text="HLM: Toggle headland automatic"/>
+		<text name="input_HLM_AUTOON" text="HLM: Turn on headland automatic"/>
+		<text name="input_HLM_AUTOOFF" text="HLM: Turn off headland automatic"/>
 		
 		<text name="text_HLM_isActive" text="Headland-Mode active"/>
 		<text name="text_HLM_configuration" text="Headlandmanagement"/>

--- a/l10n/l10n_fr.xml
+++ b/l10n/l10n_fr.xml
@@ -16,6 +16,8 @@
 		<text name="text_HLM_notInstalled" text="Sans gestion des tournières"/>
 		<text name="text_HLM_installed_short" text="Installée"/>
 		<text name="text_HLM_notInstalled_short" text="Non installée"/>
+		<text name="text_HLM_implementTypeLoaded" text="Configuration loaded for implement type"/>
+		<text name="text_HLM_implementTypeSaved" text="Configuration saved for implement type"/>
 
 		<text name="text_HLM_type_Plow" text="Plow"/>
 		<text name="text_HLM_type_Cultivator" text="Cultivator"/>

--- a/l10n/l10n_fr.xml
+++ b/l10n/l10n_fr.xml
@@ -6,6 +6,9 @@
     	<text name="input_HLM_SWITCHOFF" text="Mode champ" />	
     	<text name="input_HLM_SHOWGUI" text="Fourrière : Paramètres" />
     	<text name="input_HLM_MAINSWITCH" text="HLM: Switch on/off"/>
+		<text name="input_HLM_TOGGLEAUTO" text="HLM: Toggle headland automatic"/>
+		<text name="input_HLM_AUTOON" text="HLM: Turn on headland automatic"/>
+		<text name="input_HLM_AUTOOFF" text="HLM: Turn off headland automatic"/>
 		
 		<text name="text_HLM_isActive" text="Mode fourrière actif"/>
 		<text name="text_HLM_configuration" text="Gestion des fourrières"/>

--- a/l10n/l10n_fr.xml
+++ b/l10n/l10n_fr.xml
@@ -17,6 +17,15 @@
 		<text name="text_HLM_installed_short" text="Installée"/>
 		<text name="text_HLM_notInstalled_short" text="Non installée"/>
 
+		<text name="text_HLM_type_Plow" text="Plow"/>
+		<text name="text_HLM_type_Cultivator" text="Cultivator"/>
+		<text name="text_HLM_type_Roller" text="Roller"/>
+		<text name="text_HLM_type_Sowingmachine" text="Sowingmachine"/>
+		<text name="text_HLM_type_Mulcher" text="Mulcher"/>
+		<text name="text_HLM_type_Combine" text="Combine"/>
+		<text name="text_HLM_type_Foragewagon" text="Foragewagon"/>
+		<text name="text_HLM_type_Baler" text="Baler"/>
+		
 		<text name="hlmgui_title" text="Gestion des fourrières : configuration pour "/>
 		<text name="hlmgui_on" text="activé"/>
 		<text name="hlmgui_off" text="éteint"/>

--- a/l10n/l10n_it.xml
+++ b/l10n/l10n_it.xml
@@ -17,6 +17,8 @@
 			<text name="text_HLM_notInstalled" text="Gestione Capezzagna non è installata"/>
 			<text name="text_HLM_installed_short" text="Installato"/>
 			<text name="text_HLM_notInstalled_short" text="Non Installato"/>
+			<text name="text_HLM_implementTypeLoaded" text="Configuration loaded for implement type"/>
+			<text name="text_HLM_implementTypeSaved" text="Configuration saved for implement type"/>
 
 			<text name="text_HLM_type_Plow" text="Plow"/>
 			<text name="text_HLM_type_Cultivator" text="Cultivator"/>

--- a/l10n/l10n_it.xml
+++ b/l10n/l10n_it.xml
@@ -18,6 +18,15 @@
 			<text name="text_HLM_installed_short" text="Installato"/>
 			<text name="text_HLM_notInstalled_short" text="Non Installato"/>
 
+			<text name="text_HLM_type_Plow" text="Plow"/>
+			<text name="text_HLM_type_Cultivator" text="Cultivator"/>
+			<text name="text_HLM_type_Roller" text="Roller"/>
+			<text name="text_HLM_type_Sowingmachine" text="Sowingmachine"/>
+			<text name="text_HLM_type_Mulcher" text="Mulcher"/>
+			<text name="text_HLM_type_Combine" text="Combine"/>
+			<text name="text_HLM_type_Foragewagon" text="Foragewagon"/>
+			<text name="text_HLM_type_Baler" text="Baler"/>
+			
 			<text name="hlmgui_title" text="Gestione Capezzagna: Impostazioni per "/>
 			<text name="hlmgui_on" text="ON"/>
 			<text name="hlmgui_off" text="OFF"/>

--- a/l10n/l10n_it.xml
+++ b/l10n/l10n_it.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
   <translationContributors>Markus33-ITA</translationContributors>
-	  <texts>
-		<text name="input_HLM_TOGGLESTATE" text="Modalità capezzagna / Modalità campo"/>	
-		<text name="input_HLM_SWITCHON" text="Modalità capezzagna" />
-		<text name="input_HLM_SWITCHOFF" text="Modalità campo" />	
-		<text name="input_HLM_SHOWGUI" text="Capezzagna: Impostazioni" />
-		<text name="input_HLM_MAINSWITCH" text="HLM: Switch on/off"/>
+		<texts>
+			<text name="input_HLM_TOGGLESTATE" text="Modalità capezzagna / Modalità campo"/>	
+			<text name="input_HLM_SWITCHON" text="Modalità capezzagna" />
+			<text name="input_HLM_SWITCHOFF" text="Modalità campo" />	
+			<text name="input_HLM_SHOWGUI" text="Capezzagna: Impostazioni" />
+			<text name="input_HLM_MAINSWITCH" text="HLM: Switch on/off"/>
+			<text name="input_HLM_TOGGLEAUTO" text="HLM: Toggle headland automatic"/>
+			<text name="input_HLM_AUTOON" text="HLM: Turn on headland automatic"/>
+			<text name="input_HLM_AUTOOFF" text="HLM: Turn off headland automatic"/>
 	
-		<text name="text_HLM_isActive" text="Modalità capezzagna attiva"/>
+			<text name="text_HLM_isActive" text="Modalità capezzagna attiva"/>
 			<text name="text_HLM_configuration" text="Gestione Capezzagna"/>
 			<text name="text_HLM_installed" text="Gestione Capezzagna installata"/>
 			<text name="text_HLM_notInstalled" text="Gestione Capezzagna non è installata"/>

--- a/l10n/l10n_ru.xml
+++ b/l10n/l10n_ru.xml
@@ -16,6 +16,8 @@
 		<text name="text_HLM_notInstalled" text="Headlandmanagement не установлен"/>
 		<text name="text_HLM_installed_short" text="Установлен"/>
 		<text name="text_HLM_notInstalled_short" text="Не установлен"/>
+		<text name="text_HLM_implementTypeLoaded" text="Configuration loaded for implement type"/>
+		<text name="text_HLM_implementTypeSaved" text="Configuration saved for implement type"/>
 
 		<text name="text_HLM_type_Plow" text="Plow"/>
 		<text name="text_HLM_type_Cultivator" text="Cultivator"/>

--- a/l10n/l10n_ru.xml
+++ b/l10n/l10n_ru.xml
@@ -6,6 +6,9 @@
 		<text name="input_HLM_SWITCHOFF" text="Режим - Поле" />
 		<text name="input_HLM_SHOWGUI" text="Разворотная полоса: Настройки" />
 		<text name="input_HLM_MAINSWITCH" text="HLM: Switch on/off"/>
+		<text name="input_HLM_TOGGLEAUTO" text="HLM: Toggle headland automatic"/>
+		<text name="input_HLM_AUTOON" text="HLM: Turn on headland automatic"/>
+		<text name="input_HLM_AUTOOFF" text="HLM: Turn off headland automatic"/>
 		
 		<text name="text_HLM_isActive" text="Режим Разворотной полосы активен"/>
 		<text name="text_HLM_configuration" text="Headlandmanagement"/>

--- a/l10n/l10n_ru.xml
+++ b/l10n/l10n_ru.xml
@@ -17,6 +17,15 @@
 		<text name="text_HLM_installed_short" text="Установлен"/>
 		<text name="text_HLM_notInstalled_short" text="Не установлен"/>
 
+		<text name="text_HLM_type_Plow" text="Plow"/>
+		<text name="text_HLM_type_Cultivator" text="Cultivator"/>
+		<text name="text_HLM_type_Roller" text="Roller"/>
+		<text name="text_HLM_type_Sowingmachine" text="Sowingmachine"/>
+		<text name="text_HLM_type_Mulcher" text="Mulcher"/>
+		<text name="text_HLM_type_Combine" text="Combine"/>
+		<text name="text_HLM_type_Foragewagon" text="Foragewagon"/>
+		<text name="text_HLM_type_Baler" text="Baler"/>
+		
 		<text name="hlmgui_title" text="Headlandmanagement: Настройки для "/>
 		<text name="hlmgui_on" text="вкл"/>
 		<text name="hlmgui_off" text="выкл"/>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.2</version>
+	<version>2.9.5.3</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.4</version>
+	<version>2.9.5.5</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.4.2</version>
+	<version>2.9.5.0</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.8</version>
+	<version>2.9.5.9</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.9</version>
+	<version>2.9.9.0</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.0</version>
+	<version>2.9.5.1</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>
@@ -53,6 +53,7 @@ V2.1.0.0:
 - Headland automatic control now independent of Guidance Steering
 - Optional automatic return to field mode after turn
 - On/off switch added (lShift+lAlt+X)
+- Option to temporary disable headland automatic by key (keybindings not pre-defined)
 - Revised status display in vehicle HUD
 
 ]]>
@@ -98,6 +99,7 @@ V2.1.0.0:
 - Vorgewendeautomatik unabhängig von Guidance Steering
 - Wahlweise automatische Rückkehr in den Feldmodus nach Abschluss einer Wende
 - An/Aus-Schalter ergänzt (lShift+lAlt+X)
+- Option, die Vorgewende Automatik vorübergehend per Tastendruck abzuschalten (Tasten ist nicht vorbelegt)
 - Überarbeitete Statusanzeige im Fahrzeug HUD
 
 ]]>
@@ -232,7 +234,10 @@ V2.x.x.x:
 		<action name="HLM_SWITCHOFF" categorie="VEHICLE" ignoreComboMask="false" />
 		<action name="HLM_SWITCHON" categorie="VEHICLE" ignoreComboMask="false" />
 		<action name="HLM_SHOWGUI" categorie="VEHICLE" ignoreComboMask="false" />
-		<action name="HLM_MAINSWITCH" categorie="VEHICLE" ignoseComboMask="false" />
+		<action name="HLM_MAINSWITCH" categorie="VEHICLE" ignoreComboMask="false" />
+		<action name="HLM_TOGGLEAUTO" categorie="VEHICLE" ignoreComboMask="false" />
+		<action name="HLM_AUTOON" categorie="VEHICLE" ignoreComboMask="false" />
+		<action name="HLM_AUTOOFF" categorie="VEHICLE" ignoreComboMask="false" />
 	</actions>
 	<inputBinding>	
 		<actionBinding action="HLM_TOGGLESTATE">

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.3</version>
+	<version>2.9.5.4</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.6</version>
+	<version>2.9.5.7</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.1</version>
+	<version>2.9.5.2</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.5</version>
+	<version>2.9.5.6</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.5.7</version>
+	<version>2.9.5.8</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
 	<author>Jason06 / Glowins Modschmiede</author>
-	<version>2.9.9.0</version>
+	<version>2.1.0.RC0</version>
 	<contributors>Agrarplay und LU Wohnzimmer, Kynuska, Gonimy-Vetrom, Lactic68, Markus33-ITA, PapaTim68</contributors >
 
 	<title>


### PR DESCRIPTION
-- Make Headland Detection independent from other mods like GS
-- Two nodes: front node + back node
-- Adapt front/back nodes, if implement is being attached or detached
-- Detect, if turn has ended --> Headland Management with automatic field mode
-- Separate raising of front and back implement, each when reaching headland
-- Enable manual override of trigger controlled actions
-- Turn Headland Management on/off
-- Option to temporary disable headland automatic by key
-- Auto-Resume if trigger leaves headland area
-- Save configuration locally with implement-type